### PR TITLE
Email sender name && Resending email

### DIFF
--- a/backend/src/common/utils/email.util.ts
+++ b/backend/src/common/utils/email.util.ts
@@ -1,0 +1,2 @@
+export const getEmailFromField = (name: string, email: string): string =>
+  `${name} <${email}>`;

--- a/backend/src/services/mail.service.ts
+++ b/backend/src/services/mail.service.ts
@@ -10,6 +10,8 @@ import { HttpCode, HttpError } from 'growup-shared';
 import { SuccessResponse } from '~/common/models/responses/success';
 import { env } from '~/config/env';
 
+import { getEmailFromField } from '~/common/utils/email.util';
+
 const readFile = promisify(fs.readFile);
 
 const getUrl = (host: string, token: string): string => {
@@ -43,7 +45,7 @@ const sendMail = async (
   const url = getUrl(host, token);
 
   const mail = {
-    from: env.email.name,
+    from: getEmailFromField('Grow Up', env.email.name),
     to: email,
     subject: 'Complete registration',
     html: template({ url }),

--- a/backend/src/services/registration-token.service.ts
+++ b/backend/src/services/registration-token.service.ts
@@ -10,6 +10,12 @@ import { HttpCode, HttpError } from 'growup-shared';
 const createRegistrationToken = async (
   user: User,
 ): Promise<RegistrationToken> => {
+  if (user.firstName && user.lastName)
+    throw new HttpError({
+      status: HttpCode.BAD_REQUEST,
+      message: 'User already finished registration process',
+    });
+
   const tokenRepository = getCustomRepository(RegistrationTokenRepository);
 
   const target = await tokenRepository.findOne({ user });


### PR DESCRIPTION
Changed email sender name from `growup.bsa@gmail.com` to `Grow Up`. And fixed bug when admin could resend activation email to already have finished registration user.